### PR TITLE
【ログインAPI】20200519

### DIFF
--- a/api/src/main/java/com/lifegraph/team20/controllers/AuthController.java
+++ b/api/src/main/java/com/lifegraph/team20/controllers/AuthController.java
@@ -55,7 +55,7 @@ public class AuthController {
   public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
 
     Authentication authentication = authenticationManager.authenticate(
-        new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+        new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword()));
 
     SecurityContextHolder.getContext().setAuthentication(authentication);
     String jwt = jwtUtils.generateJwtToken(authentication);
@@ -74,7 +74,7 @@ public class AuthController {
 
   @PostMapping("/signup")
   public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
-    if (userRepository.existsByUsername(signUpRequest.getUsername())) {
+    if (userRepository.existsByEmail(signUpRequest.getUsername())) {
       return ResponseEntity
           .badRequest()
           .body(new MessageResponse("Error: Username is already taken!"));

--- a/api/src/main/java/com/lifegraph/team20/payload/request/LoginRequest.java
+++ b/api/src/main/java/com/lifegraph/team20/payload/request/LoginRequest.java
@@ -4,17 +4,17 @@ import javax.validation.constraints.NotBlank;
 
 public class LoginRequest {
   @NotBlank
-  private String username;
+  private String email;
 
   @NotBlank
   private String password;
 
-  public String getUsername() {
-    return username;
+  public String getEmail() {
+    return email;
   }
 
-  public void setUsername(String username) {
-    this.username = username;
+  public void setEmail(String email) {
+    this.email = email;
   }
 
   public String getPassword() {

--- a/api/src/main/java/com/lifegraph/team20/repository/UserRepository.java
+++ b/api/src/main/java/com/lifegraph/team20/repository/UserRepository.java
@@ -9,9 +9,9 @@ import com.lifegraph.team20.models.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findByUsername(String username);
+  Optional<User> findByemail(String email);
 
-  Boolean existsByUsername(String username);
+  Boolean existsByemail(String email);
 
   Boolean existsByEmail(String email);
 }

--- a/api/src/main/java/com/lifegraph/team20/security/services/UserDetailsServiceImpl.java
+++ b/api/src/main/java/com/lifegraph/team20/security/services/UserDetailsServiceImpl.java
@@ -19,7 +19,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
   @Transactional
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
     User user = userRepository.findByemail(email)
-        .orElseThrow(() -> new UsernameNotFoundException("User Not Found with username: " + email));
+        .orElseThrow(() -> new UsernameNotFoundException("User Not Found with email: " + email));
 
     return UserDetailsImpl.build(user);
   }

--- a/api/src/main/java/com/lifegraph/team20/security/services/UserDetailsServiceImpl.java
+++ b/api/src/main/java/com/lifegraph/team20/security/services/UserDetailsServiceImpl.java
@@ -17,9 +17,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
   @Override
   @Transactional
-  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    User user = userRepository.findByUsername(username)
-        .orElseThrow(() -> new UsernameNotFoundException("User Not Found with username: " + username));
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    User user = userRepository.findByemail(email)
+        .orElseThrow(() -> new UsernameNotFoundException("User Not Found with username: " + email));
 
     return UserDetailsImpl.build(user);
   }


### PR DESCRIPTION
# レビュー観点
ユーザーネームでのログインではなくメールアドレスでのログインを可能にしました。

# 変更内容／作業内容
 - [ ] ログインAPIの仕様変更
 

# Before（画面に変更がある場合）
![image](https://user-images.githubusercontent.com/62986164/82236794-9a750000-996f-11ea-8aa2-142ba0b23c35.png)

# After （画面に変更がある場合）
![image](https://user-images.githubusercontent.com/62986164/82236709-787b7d80-996f-11ea-841a-19c9db15f8a0.png)

