### PR TITLE
【Top画面ボタンの遷移先修正】20200519

### DIFF
--- a/vue/src/views/Top.vue
+++ b/vue/src/views/Top.vue
@@ -17,7 +17,7 @@
       <Chart />
     </div>
     <div class="edit_button">
-      <a href="./reference" class="btn-square-pop">編集</a>
+      <a href="./register" class="btn-square-pop">編集</a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# レビュー観点
Top画面にある編集ボタンの遷移先がバグっていたので修正しました。

# 変更内容／作業内容
Top画面の編集ボタン

